### PR TITLE
Fix adjustment of sampling interval on monitored item

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -225,7 +225,11 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
     }
         
     /* Adjust sampling interval */
-    if(params->samplingInterval < 0.0) {
+
+    const bool samplingIntervalSameAsPublishInterval = params->samplingInterval < 0;
+    const bool samplingIntervalSameFastestPossible = params->samplingInterval == 0;
+
+    if(samplingIntervalSameAsPublishInterval) {
         /* A negative number indicates that the sampling interval is the
          * publishing interval of the Subscription. */
         if(!mon->subscription) {
@@ -243,7 +247,7 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
                 params->samplingInterval = -1.0;
             }
         }
-    } else {
+    } else if(!samplingIntervalSameFastestPossible) {
         /* Adjust positive sampling interval to lie within the limits */
         UA_BOUNDEDVALUE_SETWBOUNDS(server->config.samplingIntervalLimits,
                                    params->samplingInterval, params->samplingInterval);


### PR DESCRIPTION
Adjustment sampling interval is different in v1.3.5 than it was in v1.3.2. They have added a negative value which means samplingInterval = pusblishInterval. And they forgot (or stop using) 0 = fastestPossible.